### PR TITLE
Adding Matt's About Us Info (Section A)

### DIFF
--- a/src/main/webapp/aboutus.html
+++ b/src/main/webapp/aboutus.html
@@ -29,11 +29,11 @@ limitations under the License.
       </ul>
     </nav>
     <h1>About Our Team</h1>
-    <h2>Teammate A Name</h2>
+    <h2>Matt Salemi</h2>
     <ul>
-      <li>Summer Feelz: </li>
-      <li>Aspirational Hobby: </li>
-      <li>Ask me About: </li>
+      <li>Summer Feelz: Passionate, Enthusiastic, Curious </li>
+      <li>Aspirational Hobby: Traveling</li>
+      <li>Ask me About: The Environment</li>
     </ul>
     <h2>Teammate B Name</h2>
     <ul>


### PR DESCRIPTION
This pull request includes adding my name and information to the website. The changes I made were added to aboutus.html under section A. Here is an image of what the updated section A looks like:

<img width="371" alt="Screen Shot 2019-05-18 at 1 52 31 PM" src="https://user-images.githubusercontent.com/50641985/57973255-2f67a680-7974-11e9-9440-fe693f8e8d6d.png">
