### PR TITLE
Add average message length to stats

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.HashSet;
+import java.util.HashMap;
 
 /** Provides access to the data stored in Datastore. */
 public class Datastore {
@@ -148,5 +149,33 @@ public class Datastore {
       }
     }
     return users.size();
+  }
+
+  /** Returns the most active user. */
+  public String getMostActiveUser(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    HashMap<String, Integer> messages_per_user = new HashMap<String, Integer>();
+    for (Entity entity : results.asIterable()) {
+      try {
+        String userName = (String) entity.getProperty("user");
+        int count = messages_per_user.containsKey(userName) ? messages_per_user.get(userName) : 0;
+        messages_per_user.put(userName, count + 1);
+      } catch (Exception e) {
+        System.err.println("Error reading message.");
+        System.err.println(entity.toString());
+        e.printStackTrace();
+      }
+    }
+    String most_active = "";
+    int max_messages = 0;
+    for (String user : messages_per_user.keySet()) {
+      int curr_messages = messages_per_user.get(user);
+      if (curr_messages > max_messages){
+        max_messages = curr_messages;
+        most_active = user;
+      }
+    }
+    return most_active;
   }
 }

--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -89,6 +89,26 @@ public class Datastore {
     return results.countEntities(FetchOptions.Builder.withLimit(1000));
   }
 
+  /** Returns the average message length. */
+  public double getAverageMessageLength(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    double total_length = 0.0;
+    double num_messages = 0.0;
+    for (Entity entity : results.asIterable()) {
+      try {
+        String text = (String) entity.getProperty("text");
+        total_length += text.length();
+        num_messages += 1;
+      } catch (Exception e) {
+        System.err.println("Error reading message.");
+        System.err.println(entity.toString());
+        e.printStackTrace();
+      }
+    }
+    return total_length / num_messages;
+  }
+
   /** Returns the total number of users. */
   public int getTotalUserCount(){
     Query query = new Query("Message");

--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -109,6 +109,29 @@ public class Datastore {
     return total_length / num_messages;
   }
 
+  /** Returns the text of the longest message */
+  public String getLongestMessage(){
+    Query query = new Query("Message");
+    PreparedQuery results = datastore.prepare(query);
+    int max_len = 0;
+    String msg_contents = "";
+    for (Entity entity : results.asIterable()) {
+      try {
+        String text = (String) entity.getProperty("text");
+        int curr_len = text.length();
+        if (curr_len > max_len){
+          max_len = curr_len;
+          msg_contents = text;
+        }
+      } catch (Exception e) {
+        System.err.println("Error reading message.");
+        System.err.println(entity.toString());
+        e.printStackTrace();
+      }
+    }
+    return msg_contents;
+  }
+
   /** Returns the total number of users. */
   public int getTotalUserCount(){
     Query query = new Query("Message");

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -33,10 +33,12 @@ public class StatsPageServlet extends HttpServlet{
     response.setContentType("application/json");
 
     int messageCount = datastore.getTotalMessageCount();
+    double averageMessageLength = datastore.getAverageMessageLength();
     int userCount = datastore.getTotalUserCount();
 
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("messageCount", messageCount);
+    jsonObject.addProperty("averageMessageLength", averageMessageLength);
     jsonObject.addProperty("userCount", userCount);
     response.getOutputStream().println(jsonObject.toString());
   }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -36,12 +36,14 @@ public class StatsPageServlet extends HttpServlet{
     double averageMessageLength = datastore.getAverageMessageLength();
     String longestMessage = datastore.getLongestMessage();
     int userCount = datastore.getTotalUserCount();
+    String mostActiveUser = datastore.getMostActiveUser();
 
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("messageCount", messageCount);
     jsonObject.addProperty("averageMessageLength", averageMessageLength);
     jsonObject.addProperty("longestMessage", longestMessage);
     jsonObject.addProperty("userCount", userCount);
+    jsonObject.addProperty("mostActiveUser", mostActiveUser);
     response.getOutputStream().println(jsonObject.toString());
   }
 }

--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -34,11 +34,13 @@ public class StatsPageServlet extends HttpServlet{
 
     int messageCount = datastore.getTotalMessageCount();
     double averageMessageLength = datastore.getAverageMessageLength();
+    String longestMessage = datastore.getLongestMessage();
     int userCount = datastore.getTotalUserCount();
 
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("messageCount", messageCount);
     jsonObject.addProperty("averageMessageLength", averageMessageLength);
+    jsonObject.addProperty("longestMessage", longestMessage);
     jsonObject.addProperty("userCount", userCount);
     response.getOutputStream().println(jsonObject.toString());
   }

--- a/src/main/webapp/js/stats-page-loader.js
+++ b/src/main/webapp/js/stats-page-loader.js
@@ -11,10 +11,12 @@ function fetchStats(){
     const averageMessageLengthElement = buildStatElement('Average message length: ' + stats.averageMessageLength);
     const longestMessage = buildStatElement('Longest Message: ' + stats.longestMessage);
     const userCountElement = buildStatElement('User count: ' + stats.userCount);
+    const mostActiveUser = buildStatElement('Most Active User: ' + stats.mostActiveUser);
     statsContainer.appendChild(messageCountElement);
     statsContainer.appendChild(averageMessageLengthElement);
     statsContainer.appendChild(longestMessage);
     statsContainer.appendChild(userCountElement);
+    statsContainer.appendChild(mostActiveUser);
   });
 }
 

--- a/src/main/webapp/js/stats-page-loader.js
+++ b/src/main/webapp/js/stats-page-loader.js
@@ -9,9 +9,11 @@ function fetchStats(){
 
     const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
     const averageMessageLengthElement = buildStatElement('Average message length: ' + stats.averageMessageLength);
+    const longestMessage = buildStatElement('Longest Message: ' + stats.longestMessage);
     const userCountElement = buildStatElement('User count: ' + stats.userCount);
     statsContainer.appendChild(messageCountElement);
     statsContainer.appendChild(averageMessageLengthElement);
+    statsContainer.appendChild(longestMessage);
     statsContainer.appendChild(userCountElement);
   });
 }

--- a/src/main/webapp/js/stats-page-loader.js
+++ b/src/main/webapp/js/stats-page-loader.js
@@ -8,8 +8,10 @@ function fetchStats(){
     statsContainer.innerHTML = '';
 
     const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+    const averageMessageLengthElement = buildStatElement('Average message length: ' + stats.averageMessageLength);
     const userCountElement = buildStatElement('User count: ' + stats.userCount);
     statsContainer.appendChild(messageCountElement);
+    statsContainer.appendChild(averageMessageLengthElement);
     statsContainer.appendChild(userCountElement);
   });
 }


### PR DESCRIPTION
This pull request contains a commit which consists of adding a getAverageMessageLength function to datastore.java. This function uses a message query to sum the length of all messages and divide by the number of messages. The average length is added to stats and stats.html as a double. This pull request also contains a couple additional lines to call the function and add the average message length to the stats.html page.