### PR TITLE
Basic message image/formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@ limitations under the License.
       <version>1.52.0</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+    <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>1.6</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -79,7 +79,7 @@ public class MessageServlet extends HttpServlet {
     String user = userService.getCurrentUser().getEmail();
     String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    String regex = "(https?://\\S+\\.(png|jpg))";
+    String regex = "(https?://\\S+\\.(png|jpg|gif))";
 	String replacement = "<img src=\"$1\" />";
 	String textWithImagesReplaced = userText.replaceAll(regex, replacement);
 
@@ -99,7 +99,11 @@ public class MessageServlet extends HttpServlet {
 		i += 1;
 	}
 
-    Message message = new Message(user, textWithImagesReplaced);
+	regex = "(https?://www.youtube.com/\\S+)";
+	replacement = "<iframe src=\"$1\"></iframe>";
+	String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
+
+    Message message = new Message(user, textWithMediaReplaced);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,9 +76,13 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    Message message = new Message(user, text);
+    String regex = "(https?://\\S+\\.(png|jpg))";
+	String replacement = "<img src=\"$1\" />";
+	String textWithImagesReplaced = userText.replaceAll(regex, replacement);
+
+    Message message = new Message(user, textWithImagesReplaced);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 import org.apache.commons.validator.routines.UrlValidator;
+import java.util.regex.*;
 
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
@@ -87,20 +88,15 @@ public class MessageServlet extends HttpServlet {
     replacement = "<iframe src=\"$1\" width=\"560\" height=\"315\"></iframe>";
     String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
 
-    int i = 0;
-    String[] schemes = {"http","https"};
-    UrlValidator urlValidator = new UrlValidator(schemes);
-    while (true) {
-		  i = textWithMediaReplaced.indexOf(" src=\"", i);
-		  if (i == -1) {
-			 break;
-		  }
-		  int end_index = textWithMediaReplaced.indexOf("\"", i + 7);
-		  String url = textWithMediaReplaced.substring(i + 6, end_index);
-		  if (!urlValidator.isValid(url)) {
-			 System.out.println("URL is not valid!");
-		  }
-		  i += 1;
+    Pattern pattern = Pattern.compile("src=(.*?)/>");
+    Matcher m = pattern.matcher(textWithMediaReplaced);
+    UrlValidator validator = new UrlValidator();
+    while (m.find()) {
+        String url = m.group(1);
+        url = url.substring(1, url.length() - 2);   //Strip off extra quotations
+        if (!validator.isValid(url)) {
+            System.out.println("URL " + url + " is not vaild.");
+        }
     }
 
     Message message = new Message(user, textWithMediaReplaced);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -83,25 +83,25 @@ public class MessageServlet extends HttpServlet {
     String replacement = "<img src=\"$1\" />";
     String textWithImagesReplaced = userText.replaceAll(regex, replacement);
 
+    regex = "(https?://www.youtube.com/\\S+)";
+    replacement = "<iframe src=\"$1\" width=\"560\" height=\"315\"></iframe>";
+    String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
+
     int i = 0;
     String[] schemes = {"http","https"};
     UrlValidator urlValidator = new UrlValidator(schemes);
     while (true) {
-		  i = textWithImagesReplaced.indexOf("<img src=", i);
+		  i = textWithMediaReplaced.indexOf(" src=\"", i);
 		  if (i == -1) {
 			 break;
 		  }
-		  int end_index = textWithImagesReplaced.indexOf("/>", i);
-		  String url = textWithImagesReplaced.substring(i + 10, end_index - 2);
+		  int end_index = textWithMediaReplaced.indexOf("\"", i + 7);
+		  String url = textWithMediaReplaced.substring(i + 6, end_index);
 		  if (!urlValidator.isValid(url)) {
 			 System.out.println("URL is not valid!");
 		  }
 		  i += 1;
     }
-
-    regex = "(https?://www.youtube.com/\\S+)";
-    replacement = "<iframe src=\"$1\" width=\"560\" height=\"315\"></iframe>";
-    String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
 
     Message message = new Message(user, textWithMediaReplaced);
     datastore.storeMessage(message);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -80,28 +80,28 @@ public class MessageServlet extends HttpServlet {
     String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
     String regex = "(https?://\\S+\\.(png|jpg|gif))";
-	String replacement = "<img src=\"$1\" />";
-	String textWithImagesReplaced = userText.replaceAll(regex, replacement);
+    String replacement = "<img src=\"$1\" />";
+    String textWithImagesReplaced = userText.replaceAll(regex, replacement);
 
-	int i = 0;
-	String[] schemes = {"http","https"};
-	UrlValidator urlValidator = new UrlValidator(schemes);
-	while (true) {
-		i = textWithImagesReplaced.indexOf("<img src=", i);
-		if (i == -1) {
-			break;
-		}
-		int end_index = textWithImagesReplaced.indexOf("/>", i);
-		String url = textWithImagesReplaced.substring(i + 10, end_index - 2);
-		if (!urlValidator.isValid(url)) {
-			System.out.println("URL is not valid!");
-		}
-		i += 1;
-	}
+    int i = 0;
+    String[] schemes = {"http","https"};
+    UrlValidator urlValidator = new UrlValidator(schemes);
+    while (true) {
+		  i = textWithImagesReplaced.indexOf("<img src=", i);
+		  if (i == -1) {
+			 break;
+		  }
+		  int end_index = textWithImagesReplaced.indexOf("/>", i);
+		  String url = textWithImagesReplaced.substring(i + 10, end_index - 2);
+		  if (!urlValidator.isValid(url)) {
+			 System.out.println("URL is not valid!");
+		  }
+		  i += 1;
+    }
 
-	regex = "(https?://www.youtube.com/\\S+)";
-	replacement = "<iframe src=\"$1\"></iframe>";
-	String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
+    regex = "(https?://www.youtube.com/\\S+)";
+    replacement = "<iframe src=\"$1\" width=\"560\" height=\"315\"></iframe>";
+    String textWithMediaReplaced = textWithImagesReplaced.replaceAll(regex, replacement);
 
     Message message = new Message(user, textWithMediaReplaced);
     datastore.storeMessage(message);

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+import org.apache.commons.validator.routines.UrlValidator;
 
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
@@ -81,6 +82,22 @@ public class MessageServlet extends HttpServlet {
     String regex = "(https?://\\S+\\.(png|jpg))";
 	String replacement = "<img src=\"$1\" />";
 	String textWithImagesReplaced = userText.replaceAll(regex, replacement);
+
+	int i = 0;
+	String[] schemes = {"http","https"};
+	UrlValidator urlValidator = new UrlValidator(schemes);
+	while (true) {
+		i = textWithImagesReplaced.indexOf("<img src=", i);
+		if (i == -1) {
+			break;
+		}
+		int end_index = textWithImagesReplaced.indexOf("/>", i);
+		String url = textWithImagesReplaced.substring(i + 10, end_index - 2);
+		if (!urlValidator.isValid(url)) {
+			System.out.println("URL is not valid!");
+		}
+		i += 1;
+	}
 
     Message message = new Message(user, textWithImagesReplaced);
     datastore.storeMessage(message);

--- a/src/main/webapp/css/user-page.css
+++ b/src/main/webapp/css/user-page.css
@@ -40,6 +40,13 @@
   margin: 5px;
 }
 
+/* Make sure images fit well within a message*/
+.message-body img {
+  display: block;
+  margin-top: 25px;
+  max-width: 75%;
+}
+
 /* Use this to hide certain elements like forms if the
    user is not logged in or viewing their own page. */
 .hidden {


### PR DESCRIPTION
This pull request adds the ability to include images in messages. Users can include a link to an image and when the message is being read, the plain text will be replaced with a link to the picture. The image also has basic formatting to keep it within the size of the message.

<img width="616" alt="Screen Shot 2019-06-07 at 5 17 54 PM" src="https://user-images.githubusercontent.com/50641985/59134137-3157d080-8948-11e9-875e-81e069b6fb4f.png">
